### PR TITLE
Increase accuracy of gps_distance from meter to cm.

### DIFF
--- a/BB3/App/etc/format.c
+++ b/BB3/App/etc/format.c
@@ -294,6 +294,12 @@ void format_distance(char * buf, float in)
 	}
 }
 
+/**
+ * Select the appropriate unit for the given distance.
+ *
+ * @param buf a character buffer receiving the unit.
+ * @param in the distance in meter.
+ */
 void format_distance_units(char * buf, float in)
 {
 	switch (config_get_select(&config.units.distance))

--- a/BB3/App/etc/geo_calc.c
+++ b/BB3/App/etc/geo_calc.c
@@ -171,7 +171,7 @@ void geo_destination(int32_t lat1, int32_t lon1, float angle, float distance_km,
  * \param FAI use FAI sphere instead of WGS ellipsoid
  * \param bearing pointer to bearing (NULL if not used)
  *
- * \return the distance in m.
+ * \return the distance in cm.
  */
 uint32_t geo_distance(int32_t lat1, int32_t lon1, int32_t lat2, int32_t lon2, bool FAI, int16_t * bearing)
 {
@@ -205,7 +205,7 @@ uint32_t geo_distance(int32_t lat1, int32_t lon1, int32_t lat2, int32_t lon2, bo
 
 //		DEBUG("#q=%0.10f\n", q);
 
-		dist = 2 * FAI_EARTH_RADIUS * asin(sqrt(q)) * 1000.0;
+		dist = 2 * FAI_EARTH_RADIUS * asin(sqrt(q)) * 100000.0;
 	}
 	else //WGS
 	{
@@ -224,15 +224,15 @@ uint32_t geo_distance(int32_t lat1, int32_t lon1, int32_t lat2, int32_t lon2, bo
 //		DEBUG("#d_lon=%0.10f\n", d_lon);
 //		DEBUG("#d_lat=%0.10f\n", d_lat);
 
-        dist = sqrt(pow(d_lon, 2) + pow(d_lat, 2)) * 1000.0;
+        dist = sqrt(pow(d_lon, 2) + pow(d_lat, 2)) * 100000.0;
 	}
 
     if (bearing)
     {
         if (d_lon  == 0 && d_lat == 0)
 			*bearing = 0;
-	else
-		*bearing = ((int16_t)to_degrees(atan2(d_lon, d_lat)) + 360) % 360;
+        else
+        	*bearing = ((int16_t)to_degrees(atan2(d_lon, d_lat)) + 360) % 360;
 //		DEBUG("a=%d\n", *bearing);
     }
 //	DEBUG("d=%lu\n\n", dist);

--- a/BB3/App/fc/fc.h
+++ b/BB3/App/fc/fc.h
@@ -194,7 +194,7 @@ typedef struct
     {
         uint32_t start_time;
         uint32_t duration;
-      	uint32_t odometer;              // in m
+      	uint32_t odometer;              // in cm
 
 
         float avg_heading_change;
@@ -234,7 +234,7 @@ typedef struct
         uint64_t utc_time;
         uint32_t ttf; //[ms]
 
-        uint32_t itow;
+        uint32_t itow;     //[ms]
         int32_t latitude;   //*10^7
         int32_t longtitude; //*10^7
         float ground_speed; //[m/s]

--- a/BB3/App/fc/navigation.c
+++ b/BB3/App/fc/navigation.c
@@ -31,7 +31,7 @@ void navigation_takeoff_distance_and_bearing()
 	{
 		bool use_fai = config_get_select(&config.units.earth_model) == EARTH_FAI;
 		int16_t bearing = 0;
-		uint32_t dist = geo_distance(fc.gnss.latitude, fc.gnss.longtitude, fc.flight.start_lat, fc.flight.start_lon, use_fai, &bearing);
+		uint32_t dist = geo_distance(fc.gnss.latitude, fc.gnss.longtitude, fc.flight.start_lat, fc.flight.start_lon, use_fai, &bearing) / 100;    // cm to m
 		fc.flight.takeoff_distance = dist;
 		fc.flight.takeoff_bearing = bearing;
 	}
@@ -54,10 +54,17 @@ void navigation_step()
 		if (last_lat != NO_LAT_DATA)
 		{
 			bool use_fai = config_get_select(&config.units.earth_model) == EARTH_FAI;
-			uint32_t dist = geo_distance(last_lat, last_lon, fc.gnss.latitude, fc.gnss.longtitude, use_fai, NULL);
+			uint32_t dist = geo_distance(last_lat, last_lon, fc.gnss.latitude, fc.gnss.longtitude, use_fai, NULL);    //cm
 
-			uint32_t delta = fc.gnss.itow - last_time;
-			float speed = dist * (1000.0 / delta);
+			uint32_t delta = fc.gnss.itow - last_time;    // ms, e.g. 2s = 2000
+
+			// speed must be in m/s. dist is in cm and delta in ms.
+			// (dist/100.0) gives dist in m.
+			// (delta/1000.0) gives delta in s.
+			// speed = (dist/100.0) / (delta/1000.0)
+			// speed = (dist/100.0) * (1000.0/delta)
+			// speed = dist/100.0 * 1000.0/delta
+			float speed = dist * 10.0 / delta;   // m/s
 			DBG("%lu %0.2f %lu", dist, speed, delta);
 
 			//do not add when gps speed is < 1 km/h

--- a/BB3/App/fc/neighbors.c
+++ b/BB3/App/fc/neighbors.c
@@ -56,7 +56,7 @@ void neighbors_update_distance(neighbor_t * nb)
 		return;
 
 	bool FAI = config_get_select(&config.units.earth_model) == EARTH_FAI;
-	uint32_t dist = geo_distance(nb->latitude, nb->longitude, fc.gnss.latitude, fc.gnss.longtitude, FAI, NULL);
+	uint32_t dist = geo_distance(nb->latitude, nb->longitude, fc.gnss.latitude, fc.gnss.longtitude, FAI, NULL) / 100; // cm to m
 
 	nb->dist = min(NB_TOO_FAR, dist);
 

--- a/BB3/App/gui/widgets/types/widget_odometer.c
+++ b/BB3/App/gui/widgets/types/widget_odometer.c
@@ -54,14 +54,15 @@ static void Odo_edit(widget_slot_t * slot, uint8_t action)
 static void Odo_update(widget_slot_t * slot)
 {
     char value[16];
+    uint32_t odometer = fc.flight.odometer / 100;    // cm to m
 
-    format_distance(value, fc.flight.odometer);
+    format_distance(value, odometer);
     lv_label_set_text(local->value, value);
     widget_update_font_size(local->value);
 
     if (local->units != NULL)
     {
-		format_distance_units(value, fc.flight.odometer);
+		format_distance_units(value, odometer);
 		lv_label_set_text(local->units, value);
     }
 }

--- a/BB3/App/gui/widgets/widget.c
+++ b/BB3/App/gui/widgets/widget.c
@@ -45,10 +45,23 @@ void widget_add_title(lv_obj_t * base, widget_slot_t * slot, char * title)
 
 #define WIDGET_VALUE_MIN_HEIGHT     16
 
+/*
+ * Add a value with optional unit to a widget, e.g ground speed 25 km/h.
+ *
+ * @param base the GUI lv_obj_t where the value should be put into
+ * @param slot the widget running in base where the value belongs to
+ * @param unit a text placed under the value, e.g. "km/h" or NULL if no label is needed.
+ * @param unit_obj receives the lv_obj_t of the unit label, so that it can
+ *                 be used later to change the unit label. If this is NULL, then
+ *                 nothing will be returned.
+ *
+ * @return the GUI lv_obj_t of the value object.
+ */
 lv_obj_t * widget_add_value(lv_obj_t * base, widget_slot_t * slot, char * unit, lv_obj_t ** unit_obj)
 {
     lv_obj_t * unit_label = NULL;
 
+    // Todo: parameter base seems to be unused and replaced by slot->obj. Remove "base" as parameter?
     if (unit != NULL)
     {
         unit_label = lv_label_create(slot->obj, NULL);


### PR DESCRIPTION
This is important for odometer, especially when hiking.
As we compute the distance every second, we get a huge
error if we have accuracy of 1 meter instead of centimeter:

For a given flight, the previous implementation lead to
17.7km and with increased accuracy to 18.7km. This is an
error of 6%.

For hiking the error is much greater, because we only walk around 1m per second. So if we walk 1.5m per second, the error is 50%.