### PR TITLE
Fixed release-note dialog to handle long texts

### DIFF
--- a/BB3/App/gui/dialog.c
+++ b/BB3/App/gui/dialog.c
@@ -247,6 +247,8 @@ void dialog_show(char * title, char * message, dialog_type_t type, gui_dialog_cb
     lv_anim_start(&a);
 
     lv_obj_t * cont = lv_cont_create(gui.dialog.window, NULL);
+    //lv_obj_add_style(cont, LV_OBJ_PART_MAIN, &cont_style);
+
     lv_cont_set_layout(cont, LV_LAYOUT_COLUMN_MID);
     lv_obj_set_auto_realign(cont, true);
     lv_obj_align_origo(cont, NULL, LV_ALIGN_CENTER, 0, 0);
@@ -254,20 +256,29 @@ void dialog_show(char * title, char * message, dialog_type_t type, gui_dialog_cb
     lv_obj_set_style_local_bg_opa(cont, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
 
     lv_obj_t * title_label = lv_label_create(cont, NULL);
+    lv_obj_add_style(title_label, LV_OBJ_PART_MAIN, &gui.styles.dialog_title);
     lv_label_set_align(title_label, LV_LABEL_ALIGN_CENTER);
     lv_label_set_long_mode(title_label, LV_LABEL_LONG_BREAK);
     lv_obj_set_width(title_label, (LV_HOR_RES * 4) / 5);
     lv_obj_set_style_local_text_font(title_label, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_montserrat_22);
     lv_label_set_text(title_label, title);
 
-    gui.dialog.textarea = lv_textarea_create(cont, NULL);
+    lv_obj_t * cont2 = lv_cont_create(cont, NULL);
+    lv_obj_add_style(cont2, LV_OBJ_PART_MAIN, &gui.styles.border1);
+    lv_cont_set_layout(cont2, LV_LAYOUT_COLUMN_MID);
+    lv_obj_set_auto_realign(cont2, true);
+    lv_obj_align_origo(cont2, NULL, LV_ALIGN_CENTER, 0, 0);
+    lv_cont_set_fit(cont2, LV_FIT_TIGHT);
+    lv_obj_set_style_local_bg_opa(cont2, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
+
+    gui.dialog.textarea = lv_textarea_create(cont2, NULL);
     lv_textarea_set_text_align(gui.dialog.textarea, LV_LABEL_ALIGN_CENTER);
     lv_obj_set_width(gui.dialog.textarea, (LV_HOR_RES * 4) / 5);
     lv_obj_set_style_local_pad_top(gui.dialog.textarea, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, 10);
     lv_textarea_set_text(gui.dialog.textarea, message);    /*Set an initial text*/
     lv_textarea_set_cursor_pos(gui.dialog.textarea, 0);
     lv_textarea_set_cursor_hidden(gui.dialog.textarea, true);
-
+    lv_obj_set_style_local_border_width(gui.dialog.textarea, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, 0);
     switch (type)
     {
         case (dialog_yes_no):
@@ -302,7 +313,7 @@ void dialog_show(char * title, char * message, dialog_type_t type, gui_dialog_cb
         case (dialog_release_note):
         {
         	lv_textarea_set_text_align(gui.dialog.textarea, LV_LABEL_ALIGN_LEFT);
-            lv_obj_set_width(title_label, LV_HOR_RES);
+            lv_obj_set_width(title_label, (LV_HOR_RES * 9) / 10);
             lv_obj_set_size(gui.dialog.textarea, (LV_HOR_RES * 9) / 10, (LV_VER_RES * 7) / 10);
             for ( int i = 0; i < 8; i++ )
     			lv_textarea_cursor_down(gui.dialog.textarea);
@@ -350,9 +361,9 @@ void dialog_show(char * title, char * message, dialog_type_t type, gui_dialog_cb
 
         case (dialog_progress):
         {
-            lv_obj_t * spinner = lv_arc_create(cont, NULL);
+            lv_obj_t * spinner = lv_arc_create(cont2, NULL);
             lv_obj_set_size(spinner, 120, 120);
-            lv_obj_align(spinner, cont, LV_ALIGN_CENTER, 0, 0);
+            lv_obj_align(spinner, cont2, LV_ALIGN_CENTER, 0, 0);
             lv_arc_set_angles(spinner, 270, 270);
             lv_obj_set_style_local_bg_opa(spinner, LV_ARC_PART_BG, LV_STATE_DEFAULT, LV_OPA_TRANSP);
             lv_obj_set_style_local_line_width(spinner, LV_ARC_PART_BG, LV_STATE_DEFAULT, 0);
@@ -363,7 +374,7 @@ void dialog_show(char * title, char * message, dialog_type_t type, gui_dialog_cb
             lv_obj_set_auto_realign(progress, true);
             lv_label_set_text(progress, "");
 
-            lv_obj_t * subtitle = lv_label_create(cont, NULL);
+            lv_obj_t * subtitle = lv_label_create(cont2, NULL);
             lv_label_set_align(subtitle, LV_LABEL_ALIGN_CENTER);
             lv_label_set_text(subtitle, "");
         }
@@ -371,7 +382,7 @@ void dialog_show(char * title, char * message, dialog_type_t type, gui_dialog_cb
 
         case (dialog_textarea):
         {
-            lv_obj_t * textbox = lv_textarea_create(cont, NULL);
+            lv_obj_t * textbox = lv_textarea_create(cont2, NULL);
 
             if (dialog_opt_param != NULL)
                 lv_textarea_set_text(textbox, dialog_opt_param);

--- a/BB3/App/gui/dialog.c
+++ b/BB3/App/gui/dialog.c
@@ -78,10 +78,26 @@ static void dialog_event_cb(lv_obj_t * obj, lv_event_t event)
             dialog_stop(dialog_res_yes, dialog_opt_data);
     }
 
-    if (gui.dialog.type == dialog_confirm || gui.dialog.type == dialog_release_note)
+    if (gui.dialog.type == dialog_confirm)
     {
         if (key == LV_KEY_ESC || key == LV_KEY_ENTER)
             dialog_stop(dialog_res_none, dialog_opt_data);
+    }
+
+    if (gui.dialog.type == dialog_release_note)
+    {
+        if (key == LV_KEY_ENTER)
+            dialog_stop(dialog_res_none, dialog_opt_data);
+        if (key == LV_KEY_HOME ) {
+			lv_textarea_cursor_down(gui.dialog.textarea);
+			lv_textarea_cursor_down(gui.dialog.textarea);
+			lv_textarea_cursor_down(gui.dialog.textarea);
+        }
+        if (key == LV_KEY_ESC ) {
+			lv_textarea_cursor_up(gui.dialog.textarea);
+			lv_textarea_cursor_up(gui.dialog.textarea);
+			lv_textarea_cursor_up(gui.dialog.textarea);
+        }
     }
 
     if (gui.dialog.type == dialog_dfu)
@@ -244,12 +260,13 @@ void dialog_show(char * title, char * message, dialog_type_t type, gui_dialog_cb
     lv_obj_set_style_local_text_font(title_label, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_montserrat_22);
     lv_label_set_text(title_label, title);
 
-    lv_obj_t * text_label = lv_label_create(cont, NULL);
-    lv_label_set_align(text_label, LV_LABEL_ALIGN_CENTER);
-    lv_label_set_long_mode(text_label, LV_LABEL_LONG_BREAK);
-    lv_obj_set_width(text_label, (LV_HOR_RES * 4) / 5);
-    lv_obj_set_style_local_pad_top(text_label, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, 10);
-    lv_label_set_text(text_label, message);
+    gui.dialog.textarea = lv_textarea_create(cont, NULL);
+    lv_textarea_set_text_align(gui.dialog.textarea, LV_LABEL_ALIGN_CENTER);
+    lv_obj_set_width(gui.dialog.textarea, (LV_HOR_RES * 4) / 5);
+    lv_obj_set_style_local_pad_top(gui.dialog.textarea, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, 10);
+    lv_textarea_set_text(gui.dialog.textarea, message);    /*Set an initial text*/
+    lv_textarea_set_cursor_pos(gui.dialog.textarea, 0);
+    lv_textarea_set_cursor_hidden(gui.dialog.textarea, true);
 
     switch (type)
     {
@@ -284,9 +301,32 @@ void dialog_show(char * title, char * message, dialog_type_t type, gui_dialog_cb
 
         case (dialog_release_note):
         {
-        	lv_label_set_align(text_label, LV_LABEL_ALIGN_LEFT);
+        	lv_textarea_set_text_align(gui.dialog.textarea, LV_LABEL_ALIGN_LEFT);
             lv_obj_set_width(title_label, LV_HOR_RES);
-            lv_obj_set_width(text_label, (LV_HOR_RES * 5) / 6);
+            lv_obj_set_size(gui.dialog.textarea, (LV_HOR_RES * 9) / 10, (LV_VER_RES * 7) / 10);
+            for ( int i = 0; i < 8; i++ )
+    			lv_textarea_cursor_down(gui.dialog.textarea);
+
+            lv_obj_t * up = lv_label_create(gui.dialog.window, NULL);
+            lv_obj_set_style_local_text_font(up, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_montserrat_22);
+            lv_obj_set_style_local_text_color(up, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
+            lv_obj_set_style_local_pad_all(up, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, 5);
+            lv_label_set_text(up, LV_SYMBOL_UP);
+            lv_obj_align(up, gui.dialog.window, LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
+
+            lv_obj_t * OK = lv_label_create(gui.dialog.window, NULL);
+            lv_obj_set_style_local_text_font(OK, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_montserrat_22);
+            lv_obj_set_style_local_text_color(OK, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GREEN);
+            lv_obj_set_style_local_pad_all(OK, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, 5);
+            lv_label_set_text(OK, LV_SYMBOL_OK);
+            lv_obj_align(OK, gui.dialog.window, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
+
+            lv_obj_t * down = lv_label_create(gui.dialog.window, NULL);
+            lv_obj_set_style_local_text_font(down, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_montserrat_22);
+            lv_obj_set_style_local_text_color(down, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
+            lv_obj_set_style_local_pad_all(down, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, 5);
+            lv_label_set_text(down, LV_SYMBOL_DOWN);
+            lv_obj_align(down, gui.dialog.window, LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
         }
         break;
 

--- a/BB3/App/gui/gui.c
+++ b/BB3/App/gui/gui.c
@@ -219,6 +219,15 @@ void gui_init_styles()
 	lv_style_set_radius(&gui.styles.note, LV_STATE_DEFAULT, 5);
 	lv_style_set_margin_bottom(&gui.styles.note, LV_STATE_DEFAULT, 5);
 
+    lv_style_init(&gui.styles.dialog_title);
+    lv_style_set_bg_color(&gui.styles.dialog_title, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+    lv_style_set_bg_opa(&gui.styles.dialog_title, LV_STATE_DEFAULT, LV_OPA_COVER);
+    lv_style_set_text_color(&gui.styles.dialog_title, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+
+    lv_style_init(&gui.styles.border1);
+    lv_style_set_border_width(&gui.styles.border1, LV_STATE_DEFAULT, 1);
+    lv_style_set_border_color(&gui.styles.border1, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+
 	//numbers only
     gui.styles.widget_fonts[FONT_8XL] = &lv_font_montserrat_140;
     gui.styles.widget_fonts[FONT_7XL] = &lv_font_montserrat_120;

--- a/BB3/App/gui/gui.h
+++ b/BB3/App/gui/gui.h
@@ -200,6 +200,8 @@ typedef struct
 		lv_style_t note;
 		lv_style_t ctx_menu;
 		const lv_font_t * widget_fonts[NUMBER_OF_WIDGET_FONTS];
+		lv_style_t dialog_title;
+		lv_style_t border1;
 	} styles;
 
 	//map

--- a/BB3/App/gui/gui.h
+++ b/BB3/App/gui/gui.h
@@ -162,6 +162,7 @@ typedef struct
 	{
         lv_obj_t * window;
         lv_group_t * group;
+        lv_obj_t * textarea;
 
         uint8_t type;
         gui_dialog_cb_t cb;


### PR DESCRIPTION
If the release_note.txt gets too long, we need the possibility to scroll
up/down. By changing the dialog message object from label to textarea we
make this possible. As a side effect, the dialog gets a border around the
text, which looks better.