### PR TITLE
[bugfix]  page switching fix -  rare crashes at take off and possibly…

### DIFF
--- a/BB3/App/fc/fc.c
+++ b/BB3/App/fc/fc.c
@@ -205,7 +205,7 @@ void fc_takeoff()
     fanet_set_mode();
     logger_start();
 
-    gui_page_set_mode(&profile.ui.autoset.take_off);
+    gui_page_set_next(&profile.ui.autoset.take_off);
 }
 
 void fc_landing()
@@ -219,7 +219,7 @@ void fc_landing()
     fanet_set_mode();
     logger_stop();
 
-    gui_page_set_mode(&profile.ui.autoset.land);
+    gui_page_set_next(&profile.ui.autoset.land);
 }
 
 //run via timer every 250ms

--- a/BB3/App/gui/gui.c
+++ b/BB3/App/gui/gui.c
@@ -250,6 +250,7 @@ void gui_init()
 {
     gui.take_screenshot = false;
     gui.dialog.active = false;
+    gui.queue = xQueueCreate(GUI_QUEUE_SIZE, sizeof(void *));
     dbg_overlay_init();
 	gui_init_styles();
 

--- a/BB3/App/gui/gui.h
+++ b/BB3/App/gui/gui.h
@@ -241,12 +241,11 @@ typedef struct
 
 	osSemaphoreId_t lock;
 
-	void * next_page;
-	
-	bool change_page;
+	xQueueHandle queue;
+
 	uint8_t take_screenshot;
 	uint8_t fps;
-	uint8_t _pad[1];
+	uint8_t _pad[2];
 
 } gui_t;
 
@@ -268,6 +267,7 @@ void gui_lock_release();
 
 void gui_show_release_note();
 
+#define GUI_QUEUE_SIZE 			2
 #define GUI_TASK_SW_ANIMATION	250
 #define GUI_STATUSBAR_HEIGHT	24
 

--- a/BB3/App/gui/tasks/page/pages.c
+++ b/BB3/App/gui/tasks/page/pages.c
@@ -129,8 +129,9 @@ void page_focus_widget(lv_obj_t * obj)
 
 void gui_page_set_next(cfg_entry_t * cfg)
 {
-	 gui.next_page = cfg;
-	 gui.change_page = true;
+	 if(xQueueSend(gui.queue, &(cfg), 0) != pdPASS) {
+		 WARN("Cannot switch page due to gui.queue full");
+	 }
 }
 
 void gui_page_set_mode(cfg_entry_t * cfg)
@@ -820,10 +821,12 @@ static void pages_loop()
 
 	widgets_update(local->page);
 
-	if (gui.change_page) {
-		gui_page_set_mode(gui.next_page);
-		gui.change_page = false;
-	}
+	void * next_page;
+
+	if(xQueueReceive(gui.queue, &(next_page), 0) == pdPASS )
+    {
+		gui_page_set_mode(next_page);
+    }
 }
 
 static void pages_stop()


### PR DESCRIPTION
… landing

Move to queue for communication between fc & gui tasks. Does proper communication between threads and fixes rare crash on take-off (and possibly landing), usually logged as:

[4114683][System][W] Timeout, trying to recover system i2c (0)

(some memory corruption)

Queue can be also used in future for further communication with GUI thread.
