### PR TITLE
Add Docker image to build Strato firmware

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,28 @@
+name: Build and publish Strato docker image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'Utilities/Docker/*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKER_CONTAINER_REGISTRY_TOKEN }}
+      - name: Build and push docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Utilities/Docker/Dockerfile
+          push: true
+          tags: ${{ github.repository_owner }}/strato-build:latest

--- a/Utilities/Docker/Dockerfile
+++ b/Utilities/Docker/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu
+
+ENV TOOLCHAIN_URL=https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-linux-amd64.tar.gz
+ENV ESP_URL=https://strato.skybean.eu/dev/esp.zip
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes \
+    git wget flex bison gperf python3 python3-pip python3-setuptools \
+    cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0 \
+    zip unzip && \
+    apt-get clean
+
+RUN mkdir -p /opt/Espressif && \
+    cd /opt/Espressif && \
+    wget --quiet $TOOLCHAIN_URL && \
+    tar xzf $(basename $TOOLCHAIN_URL) && \
+    rm $(basename $TOOLCHAIN_URL)
+
+RUN cd /opt && \
+    wget --quiet $ESP_URL && \
+    unzip -q $(basename $ESP_URL) && \
+    rm $(basename $ESP_URL)
+
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/Espressif/xtensa-esp32-elf/bin
+ENV IDF_PATH=/opt/esp/esp-idf
+ENV ADF_PATH=/opt/esp/esp-adf
+
+RUN ln -s /usr/bin/python3 /usr/bin/python && \
+    pip install -r $IDF_PATH/requirements.txt

--- a/Utilities/Docker/Dockerfile
+++ b/Utilities/Docker/Dockerfile
@@ -1,29 +1,45 @@
 FROM ubuntu
 
-ENV TOOLCHAIN_URL=https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-linux-amd64.tar.gz
+ENV ESP_TOOLCHAIN_URL=https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-linux-amd64.tar.gz
 ENV ESP_URL=https://strato.skybean.eu/dev/esp.zip
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes \
+ENV STM32CUBEIDE_URL=https://st.com/content/ccc/resource/technical/software/sw_development_suite/group0/13/d4/6b/b0/d2/fd/47/6d/stm32cubeide_deb/files/st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.deb_bundle.sh.zip/jcr:content/translations/en.st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.deb_bundle.sh.zip
+ENV STM32CUBEIDE_VERSION=1.9.0
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LICENSE_ALREADY_ACCEPTED=1
+ENV PATH="${PATH}:/opt/Espressif/xtensa-esp32-elf/bin:/opt/st/stm32cubeide_${STM32CUBEIDE_VERSION}"
+ENV IDF_PATH=/opt/esp/esp-idf
+ENV ADF_PATH=/opt/esp/esp-adf
+
+# Install general dependencies
+RUN apt-get update && \
+    apt-get install --assume-yes \
     git wget flex bison gperf python3 python3-pip python3-setuptools \
     cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0 \
     zip unzip && \
     apt-get clean
 
+# Install STM32 Cube IDE
+RUN wget --quiet $STM32CUBEIDE_URL && \
+    unzip -qp $(basename $STM32CUBEIDE_URL) > stm32cubeide-installer.sh && \
+    chmod +x stm32cubeide-installer.sh && \
+    ./stm32cubeide-installer.sh --quiet && \
+    rm stm32cubeide-installer.sh && \
+    rm $(basename $STM32CUBEIDE_URL)
+
+# Install ESP32 compiler tools (Espressif)
 RUN mkdir -p /opt/Espressif && \
     cd /opt/Espressif && \
-    wget --quiet $TOOLCHAIN_URL && \
-    tar xzf $(basename $TOOLCHAIN_URL) && \
-    rm $(basename $TOOLCHAIN_URL)
+    wget --quiet $ESP_TOOLCHAIN_URL && \
+    tar xzf $(basename $ESP_TOOLCHAIN_URL) && \
+    rm $(basename $ESP_TOOLCHAIN_URL)
 
+# Install custom ESP dependencies
 RUN cd /opt && \
     wget --quiet $ESP_URL && \
     unzip -q $(basename $ESP_URL) && \
     rm $(basename $ESP_URL)
-
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/Espressif/xtensa-esp32-elf/bin
-ENV IDF_PATH=/opt/esp/esp-idf
-ENV ADF_PATH=/opt/esp/esp-adf
 
 RUN ln -s /usr/bin/python3 /usr/bin/python && \
     pip install -r $IDF_PATH/requirements.txt


### PR DESCRIPTION
This PR adds:
1. A `Dockerfile` which can be used to build the Strato firmware
2. A GitHub Action which builds and pushes the Docker image to the GitHub registry whenever the `Dockerfile` changes

This PR is the preparation for  #247 that introduces automatic building of the Strato firmware via GitHub Actions