### PR TITLE
Implement a cache for "old" IGC files without comments

### DIFF
--- a/BB3/App/common.c
+++ b/BB3/App/common.c
@@ -290,6 +290,37 @@ void copy_dir(char * src, char * dst)
     }
 }
 
+/**
+ * Create the given directories including all parent directories.
+ * Similar to "mkdir -p".
+ *
+ * @param the directory to create (including parents)
+ * 
+ * @return 0 on success, -1 otherwise
+ */
+int red_mkdirs(char *dir)
+{
+  char *p;
+  char buffer[PATH_LEN];
+
+  p = strchr(dir, '/');
+  while ( p != NULL ) 
+    {
+      size_t len;
+
+      len = p - dir;
+      memcpy(buffer, dir, len);
+      buffer[len] = 0;
+      if ( !file_isdir(buffer) )
+    		  if ( red_mkdir(buffer) != 0 ) return -1;
+      p = strchr(p + 1, '/');
+    }
+
+  if ( red_mkdir(dir) != 0 ) return -1;
+
+  return 0;
+}
+
 void copy_dir_when_absent(char * src, char * dst)
 {
     red_mkdir(dst);
@@ -459,6 +490,18 @@ bool file_exists(char * path)
     return false;
 }
 
+bool file_isdir(char *path)
+{
+    int32_t f = red_open(path, RED_O_RDONLY);
+    if (f > 0)
+    {
+        REDSTAT stat;
+        red_fstat(f, &stat);
+        red_close(f);
+        return RED_S_ISDIR(stat.st_mode);
+    }
+    return false;
+}
 
 void touch(char * path)
 {

--- a/BB3/App/common.h
+++ b/BB3/App/common.h
@@ -243,9 +243,12 @@ int8_t complement2_7bit(uint8_t in);
 int16_t complement2_16bit(uint16_t in);
 
 bool file_exists(char * path);
+bool file_isdir(char *path);
+
 void touch(char * path);
 uint64_t file_size(int32_t file);
 char * red_gets(char * buff, uint16_t buff_len, int32_t fp);
+int red_mkdirs(char *dir);
 
 uint8_t calc_crc(uint8_t crc, uint8_t key, uint8_t data);
 uint32_t calc_crc32(uint32_t * data, uint32_t size);

--- a/BB3/App/common.h
+++ b/BB3/App/common.h
@@ -187,6 +187,7 @@ extern osThreadId_t SystemHandle;
 #define PATH_FW_DIR         PATH_SYSTEM_DIR "/fw"
 #define PATH_CACHE_DIR      PATH_SYSTEM_DIR "/cache"
 #define PATH_MAP_CACHE_DIR  PATH_CACHE_DIR "/map"
+#define PATH_LOG_CACHE_DIR  PATH_CACHE_DIR "/logs"
 
 #define PATH_CRASH_DIR      "crash"
 #define PATH_CRASH_DUMP     PATH_CRASH_DIR "/dump.bin"

--- a/BB3/App/drivers/sd.c
+++ b/BB3/App/drivers/sd.c
@@ -242,8 +242,6 @@ void sd_init()
     red_mkdir(PATH_CACHE_DIR);
     //system/cache/map
     red_mkdir(PATH_MAP_CACHE_DIR);
-    //system/cache/logs
-    red_mkdir(PATH_LOG_CACHE_DIR);
 }
 
 void sd_deinit()

--- a/BB3/App/drivers/sd.c
+++ b/BB3/App/drivers/sd.c
@@ -242,6 +242,8 @@ void sd_init()
     red_mkdir(PATH_CACHE_DIR);
     //system/cache/map
     red_mkdir(PATH_MAP_CACHE_DIR);
+    //system/cache/logs
+    red_mkdir(PATH_LOG_CACHE_DIR);
 }
 
 void sd_deinit()

--- a/BB3/App/fc/logger/igc.h
+++ b/BB3/App/fc/logger/igc.h
@@ -26,5 +26,6 @@ typedef struct flight_pos
 } flight_pos_t;
 
 bool igc_read_next_pos(int32_t igc_log_read_file, flight_pos_t *flight_pos);
+void igc_read_flight_stats(int32_t fp, flight_stats_t *f_stat);
 
 #endif /* FC_LOGGER_IGC_H_ */

--- a/BB3/App/fc/logger/logger.c
+++ b/BB3/App/fc/logger/logger.c
@@ -5,7 +5,7 @@
  *      Author: horinek
  */
 
-#define DEBUG_LEVEL	DEBUG_DBG
+// #define DEBUG_LEVEL	DEBUG_DBG
 
 #include "logger.h"
 
@@ -159,7 +159,7 @@ void logger_read_flight_stats(const char *filename, flight_stats_t *f_stat)
 	if (f_stat->start_time == FS_NO_DATA)
 	{
 		// Fallback: this is an old file without comments, so read data out of files
-	    sprintf(line, "/aaa" PATH_LOG_CACHE_DIR "/%s", filename + 5);
+	    sprintf(line, PATH_LOG_CACHE_DIR "/%s", filename + 5);
 		fp_cache = red_open(line, RED_O_RDONLY);
 		if ( fp_cache >= 0 )
 		{

--- a/BB3/App/fc/logger/logger.c
+++ b/BB3/App/fc/logger/logger.c
@@ -140,6 +140,7 @@ void logger_read_flight_stats(const char *filename, flight_stats_t *f_stat)
 {
 	int32_t fp, fp_cache;
 	char line[PATH_LEN];
+	char *p;
 
 	// Set defaults, if nothing could be found in the file:
 	f_stat->start_time = FS_NO_DATA;
@@ -159,7 +160,14 @@ void logger_read_flight_stats(const char *filename, flight_stats_t *f_stat)
 	if (f_stat->start_time == FS_NO_DATA)
 	{
 		// Fallback: this is an old file without comments, so read data out of files
-	    sprintf(line, PATH_LOG_CACHE_DIR "/%s", filename + 5);
+	  sprintf(line, PATH_LOG_CACHE_DIR "/%s", filename + 5);
+
+	  // make directory and its parents:
+	  p = strrchr(line, '/');
+	  *p = 0;
+	  red_mkdirs(line);
+	  *p = '/';
+
 		fp_cache = red_open(line, RED_O_RDONLY);
 		if ( fp_cache >= 0 )
 		{

--- a/BB3/App/fc/logger/logger.c
+++ b/BB3/App/fc/logger/logger.c
@@ -5,6 +5,8 @@
  *      Author: horinek
  */
 
+#define DEBUG_LEVEL	DEBUG_DBG
+
 #include "logger.h"
 
 #include <inttypes.h>
@@ -21,6 +23,31 @@ fc_logger_status_t logger_state()
 }
 
 /**
+ * Convert the flight statistics into a text format containing
+ * multiple lines.
+ *
+ * @param f_stat the flight statistics to convert
+ * @param buffer the buffer to hold the data [at least 100 bytes]
+ */
+static void flight_stats_to_text(flight_stats_t *f_stat, char *buffer)
+{
+  sprintf(buffer, " SKYBEAN-START-UTC-s: %" PRIu32 "\n"
+		  	  	  " SKYBEAN-DURATION-s: %" PRIu32 "\n"
+				  " SKYBEAN-ALT-MAX-m: %" PRId16 "\n"
+				  " SKYBEAN-ALT-MIN-m: %" PRId16 "\n"
+				  " SKYBEAN-CLIMB-MAX-cm: %" PRId16 "\n"
+				  " SKYBEAN-SINK-MAX-cm: %" PRId16 "\n"
+				  " SKYBEAN-ODO-m: %" PRIu32 "\n",
+				  f_stat->start_time,
+				  f_stat->duration,
+				  f_stat->max_alt,
+				  f_stat->min_alt,
+				  f_stat->max_climb,
+				  f_stat->max_sink,
+				  f_stat->odo);
+}
+
+/**
  * Write the given flight statistics into the log file by using
  * special keywords inside comments.
  *
@@ -28,58 +55,39 @@ fc_logger_status_t logger_state()
  */
 void logger_write_flight_stats(flight_stats_t f_stat)
 {
-	logger_comment(" SKYBEAN-START-UTC-s: %" PRIu32, f_stat.start_time);
-	logger_comment(" SKYBEAN-DURATION-s: %" PRIu32, f_stat.duration);
- 	logger_comment(" SKYBEAN-ALT-MAX-m: %" PRId16, f_stat.max_alt);
- 	logger_comment(" SKYBEAN-ALT-MIN-m: %" PRId16, f_stat.min_alt);
- 	logger_comment(" SKYBEAN-CLIMB-MAX-cm: %" PRId16, f_stat.max_climb);
- 	logger_comment(" SKYBEAN-SINK-MAX-cm: %" PRId16, f_stat.max_sink);
- 	logger_comment(" SKYBEAN-ODO-m: %" PRIu32, f_stat.odo);
+  char buffer[200];
+
+  flight_stats_to_text(&f_stat, buffer);
+  logger_comment(buffer);
 }
 
 /**
- * Read the flight statistics from a log file. This is either done by
- * searching for the keywords and values or by parsing the IGC file,
- * if no keywords are found (for old IGC logs).
+ * Read the flight statistics from a file where they are stored
+ * with special comments.
  *
- * @param filename the filename of the log file to parse
- * @param f_stat a pointer to the flight statistics to store the values
+ * @param fp the file pointer to read from
+ * @param f_stat a pointer to the flight statistics to save
  */
-void logger_read_flight_stats(const char *filename, flight_stats_t *f_stat)
+static void read_stats_from_file(int32_t fp, flight_stats_t *f_stat)
 {
-	int32_t fp;
-	char line[80];
-	char *p;
-
-	// Set defaults, if nothing could be found in the file:
-	f_stat->start_time = FS_NO_DATA;
-	f_stat->duration = FS_NO_DATA;
-	f_stat->max_alt = FS_NO_DATA;
-	f_stat->min_alt = FS_NO_DATA;
-	f_stat->max_climb = FS_NO_DATA;
-	f_stat->max_sink = FS_NO_DATA;
-	f_stat->odo = FS_NO_DATA;
-
-	fp = red_open(filename, RED_O_RDONLY);
-	if ( fp < 0 ) return;
-
-	red_lseek(fp, -512, RED_SEEK_END);    	// Read from the end of the file
-
-	while(1)
+  char line[80];
+  char *p;
+  
+  while(1)
 	{
 		if ( file_gets(line, sizeof(line), fp) == NULL ) break;
 
 		p = strstr(line, "SKYBEAN-START-UTC-s: ");
 		if ( p != NULL )
 		{
-			f_stat->start_time = atol(p + 17);
+			f_stat->start_time = atol(p + 21);
 			continue;
 		}
 
 		p = strstr(line, "SKYBEAN-DURATION-s: ");
 		if ( p != NULL )
 		{
-			f_stat->duration = atol(p + 21);
+			f_stat->duration = atol(p + 20);
 			continue;
 		}
 
@@ -114,16 +122,66 @@ void logger_read_flight_stats(const char *filename, flight_stats_t *f_stat)
 		p = strstr(line, "SKYBEAN-ODO-m: ");
 		if ( p != NULL )
 		{
-			f_stat->odo = atol(p + 16) * 100;   // meter in cm
+			f_stat->odo = atol(p + 15) * 100;   // meter in cm
 			continue;
 		}
 	}
+}
+
+/**
+ * Read the flight statistics from a log file. This is either done by
+ * searching for the keywords and values or by parsing the IGC file,
+ * if no keywords are found (for old IGC logs).
+ *
+ * @param filename the filename of the log file to parse
+ * @param f_stat a pointer to the flight statistics to store the values
+ */
+void logger_read_flight_stats(const char *filename, flight_stats_t *f_stat)
+{
+	int32_t fp, fp_cache;
+	char line[PATH_LEN];
+
+	// Set defaults, if nothing could be found in the file:
+	f_stat->start_time = FS_NO_DATA;
+	f_stat->duration = FS_NO_DATA;
+	f_stat->max_alt = FS_NO_DATA;
+	f_stat->min_alt = FS_NO_DATA;
+	f_stat->max_climb = FS_NO_DATA;
+	f_stat->max_sink = FS_NO_DATA;
+	f_stat->odo = FS_NO_DATA;
+
+	fp = red_open(filename, RED_O_RDONLY);
+	if ( fp < 0 ) return;
+
+	red_lseek(fp, -512, RED_SEEK_END);    	// Read from the end of the file
+	read_stats_from_file(fp, f_stat);
 
 	if (f_stat->start_time == FS_NO_DATA)
 	{
 		// Fallback: this is an old file without comments, so read data out of files
-		red_lseek(fp, 0, RED_SEEK_SET);
-		igc_read_flight_stats(fp, f_stat);
+	    sprintf(line, "/aaa" PATH_LOG_CACHE_DIR "/%s", filename + 5);
+		fp_cache = red_open(line, RED_O_RDONLY);
+		if ( fp_cache >= 0 )
+		{
+		    // There is already a cache file for flight statistics
+		    read_stats_from_file(fp_cache, f_stat);
+		    red_close(fp_cache);
+		} else {
+			// no cache file, so parse IGC directly...
+		    red_lseek(fp, 0, RED_SEEK_SET);
+		    igc_read_flight_stats(fp, f_stat);
+
+		    // ... and store values in the cache file for next reads
+		    fp_cache = red_open(line, RED_O_WRONLY | RED_O_CREAT);
+		    if ( fp_cache >= 0 )
+		    {
+		    	char buffer[200];
+			
+		    	flight_stats_to_text(f_stat, buffer);
+		    	red_write(fp_cache, buffer, strlen(buffer));
+		    	red_close(fp_cache);
+		    }
+		}
 	}
 	red_close(fp);
 }
@@ -144,21 +202,32 @@ void logger_start()
 }
 
 /**
- * printf-like function to send output to the GPS log .
+ * printf-like function to send output to the GPS log.
+ * The resulting string may contain "\n" which will
+ * result in multiple lines to be printed into the log.
  *
  * \param format a printf-like format string 
  **/ 
 void logger_comment(const char *format, ...)
 {
  	va_list arp;
- 	char text[80];
-
+ 	char text[300];
+	char *saveptr;
+	char *pch;
+	
   	va_start(arp, format);
  	vsnprintf(text, sizeof(text), format, arp);
  	va_end(arp);
 
-  	igc_comment(text);
-    // Add additional loggers here, if available.
+	// If text contains multiple lines (delimited by "\n"), then break them
+	// into multiple calls to igc_comment (whatever).
+	pch = strtok_r (text,"\n", &saveptr);
+	while (pch != NULL)
+	  {
+	    igc_comment(pch);
+	    // Add additional loggers here, if available.
+	    pch = strtok_r(NULL, "\n", &saveptr);
+	  }
 }
 
 void logger_stop()


### PR DESCRIPTION
Older firmware store IGC files without statistics in comments. Parsing data needs a lot of time. Therefore we implement a cache for this statistics.