### PR TITLE
Use YEAR/MONTH instead of YEAR.MONTH as directory names for IGC

### DIFF
--- a/BB3/App/fc/logger/igc.c
+++ b/BB3/App/fc/logger/igc.c
@@ -161,9 +161,9 @@ void igc_start_write()
 	DBG("utc_time %lu", utc_time);
 	datetime_from_epoch(utc_time, &sec, &min, &hour, &day, &wday, &month, &year);
 
-	snprintf(path, sizeof(path), "%s/%04u.%02u", PATH_LOGS_DIR, year, month);
-	red_mkdir(path);
-	snprintf(path, sizeof(path), "%s/%04u.%02u/%04u.%02u.%02u %02u.%02u.igc", PATH_LOGS_DIR, year, month, year, month, day, hour, min);
+	snprintf(path, sizeof(path), "%s/%04u/%02u", PATH_LOGS_DIR, year, month);
+	red_mkdirs(path);
+	snprintf(path, sizeof(path), "%s/%04u/%02u/%04u-%02u-%02u %02u.%02u.igc", PATH_LOGS_DIR, year, month, year, month, day, hour, min);
 	igc_log_file = red_open(path, RED_O_WRONLY | RED_O_CREAT);
 	DBG("IGC OPEN %s, res = %d", path, igc_log_file);
 	if (igc_log_file < 0)


### PR DESCRIPTION
Otherwise pilot will get more than 20 directories in 2 years where he has to scroll down to find his IGC.