### PR TITLE
Fix early debug messages before sd_init

### DIFF
--- a/BB3/App/system/debug_thread.c
+++ b/BB3/App/system/debug_thread.c
@@ -315,13 +315,30 @@ void thread_debug_start(void *argument)
             	if (!debug_file_open)
             	{
             		debug_file = red_open(DEBUG_FILE, RED_O_WRONLY | RED_O_APPEND | RED_O_CREAT);
+            		if ( debug_file < 0 )
+            		{
+            			char text[100];
+            			sprintf(text, "Unable to open " DEBUG_FILE " with error %d", red_errno);
+                		//bsod_msg("Unable to open " DEBUG_FILE " with error %d", red_errno);
+                		//bsod_msg(text);
+            		}
+            		else
+            		{
             		debug_file_open = true;
+            		}
             	}
 
+            	if ( debug_file_open )
+            	{
             	//write
-            	red_write(debug_file, (uint8_t *)(debug_tx_buffer + debug_tx_buffer_read_index), to_transmit);
+            	int16_t n = red_write(debug_file, (uint8_t *)(debug_tx_buffer + debug_tx_buffer_read_index), to_transmit);
+#if 0
+            	if ( n != to_transmit )
+            		bsod_msg("Unable to write enough bytes to " DEBUG_FILE);
+#endif
             	//sync
             	red_sync();
+            	}
             }
 
             debug_tx_buffer_lenght -= to_transmit;

--- a/BB3/App/system/system_thread.c
+++ b/BB3/App/system/system_thread.c
@@ -243,7 +243,10 @@ void thread_system_start(void *argument)
     GpioSetDirection(VCC_MAIN_EN, OUTPUT, GPIO_NOPULL);
     GpioWrite(VCC_MAIN_EN, HIGH);
 
-    //start debug thread
+	//init sd card
+	sd_init();
+
+	//start debug thread
     start_thread(thread_debug);
     gui_create_lock();
     config_set_bool(&config.debug.use_serial, true);
@@ -257,8 +260,6 @@ void thread_system_start(void *argument)
     //init PSRAM
     PSRAM_init();
 
-	//init sd card
-	sd_init();
 
     //rtc init
     rtc_init();


### PR DESCRIPTION
Initialize sd card driver before debug_thread, as debug_thread is using SD card to save debug files to.