### PR TITLE
Fix getting back from deep directory into higher ones.

### DIFF
--- a/BB3_loader/Bootloader/flash.c
+++ b/BB3_loader/Bootloader/flash.c
@@ -200,13 +200,13 @@ bool flash_loop()
                     {
                         sprintf(cwd + strlen(cwd), "/%s", last_chunk.name);
                     }
-                    else if (level > clevel) //out of the current dir
+                    else while (level > clevel) //out of the current dir
                     {
                         char * last_slash = strrchr(cwd, '/');
                         ASSERT(last_slash != NULL);
                         *last_slash = 0;
+                        level--;
                     }
-                    level = clevel;
 
                     char fname[256 + 32];
                     snprintf(fname, sizeof(fname), "%s/%s", cwd, chunk.name);

--- a/Utilities/Bundle/unpack_fw.py
+++ b/Utilities/Bundle/unpack_fw.py
@@ -59,7 +59,8 @@ for i in range(number_of_records):
         d = True
         
         if old_level > level:
-            path = path[:-1]
+            levels_up = old_level - level
+            path = path[:-levels_up]
         
         path += [name]
         os.mkdir(os.path.join(*path))
@@ -72,7 +73,8 @@ for i in range(number_of_records):
         level = (addr & (0xFFFF << 16)) >> 16
         
         if old_level > level:
-            path = path[:-1]
+            levels_up = old_level - level
+            path = path[:-levels_up]
         
         
         write_file(os.path.join(*path, name), data)


### PR DESCRIPTION
WARNING: change in BB3_loader could not be tested. So please check carefully!

The problem occurs, if the bundle has many nested dirs, like this

```
$ ./pack_fw.py 
Active branch is fix/pack-levels
  0x00000000       1027208 bytes        crc 41407D61    *BB3.bin
  0x40000000        113408 bytes        crc 45CE08B5    fanet.xlb
  0x40000001             0 bytes        crc 4E75D0D1    NEW
  0x40000002           131 bytes        crc 9AB7D63E    bootloader.fw
  0x40000003           423 bytes        crc 2C58ACA5    release_note.txt
  0x80000004             0 bytes        crc D4C7837B    [defaults]
  0x80010000             0 bytes        crc 31035C94      [vario]
  0x40020000          1731 bytes        crc 965DF2D5        default.cfg
  0x40020001          2792 bytes        crc 592C1F75        skydrop.cfg
  0x80010001             0 bytes        crc D01EBEFA      [pages]
  0x40020000           338 bytes        crc 4F2016C1        thermal.pag
  0x40020001           679 bytes        crc 0483CB5F        data.pag
  0x40020002           511 bytes        crc EAA63E90        basic.pag
  0x40020003           391 bytes        crc 021DA0D1        radar.pag
  0x40020004           445 bytes        crc B298CB4E        thermal2.pag
  0x40020005           622 bytes        crc D05B15A8        ppg.pag
  0x40020006           378 bytes        crc 42144919        map.pag

HERE we return 2 levels up. This triggers the problem.

  0x80000005             0 bytes        crc 8574C6CB    [root]
  0x40010000           561 bytes        crc 1C73A421      read-me.txt
  0x80010001             0 bytes        crc DB9D38C3      [agl]
  0x40020000           608 bytes        crc AC3CE1BB        read-me.txt
  0x80010002             0 bytes        crc DAC43607      [map]
  0x40020000           616 bytes        crc 6EC3A651        read-me.txt
  0x00001000         24240 bytes        crc 5ED8D5C3    *bootloader.bin
  0x00008000          3072 bytes        crc FC09C04F    *partition-table.bin
  0x00010000       1692320 bytes        crc 132BB439    *firmware.bin
  0x00A10000       1048576 bytes        crc 8795A07E    *storage.bin
```