### PR TITLE
unzip ZIP files in maps directory as a background task

### DIFF
--- a/BB3/App/common.c
+++ b/BB3/App/common.c
@@ -164,6 +164,19 @@ uint64_t file_size(int32_t file)
     return stat.st_size;
 }
 
+uint64_t file_size_from_name(char *path)
+{
+    int32_t f = red_open(path, RED_O_RDONLY);
+    if (f > 0)
+    {
+        REDSTAT stat;
+        red_fstat(f, &stat);
+        red_close(f);
+        return stat.st_size;
+    } else {
+    	return 0;
+    }
+}
 
 uint8_t calc_crc(uint8_t crc, uint8_t key, uint8_t data)
 {

--- a/BB3/App/common.h
+++ b/BB3/App/common.h
@@ -264,6 +264,7 @@ bool file_isdir(char *path);
 
 void touch(char * path);
 uint64_t file_size(int32_t file);
+uint64_t file_size_from_name(char *path);
 char * red_gets(char * buff, uint16_t buff_len, int32_t fp);
 int red_mkdirs(char *dir);
 

--- a/BB3/App/system/maps_unzip.c
+++ b/BB3/App/system/maps_unzip.c
@@ -1,0 +1,91 @@
+/*
+ * maps_unzip.c
+ *
+ * Unzip all ZIP files inside the maps directory and delete ZIP afterwards.
+ *
+ *  Created on: Feb 27, 2023
+ *      Author: tilmann@bubecks.de
+ */
+
+#include <string.h>
+
+#include "lib/miniz/miniz.h"
+#include "common.h"
+#include "gui/statusbar.h"
+#include "drivers/rtc.h"
+#include "etc/format.h"
+
+bool unzip_zipfile(char *target_dir, char *zip_file_path)
+{
+	mz_zip_archive zip;
+	mz_zip_zero_struct(&zip);
+	mz_zip_archive_file_stat file_stat;
+	char mess[128];
+	char path[PATH_LEN];
+
+	bool res = mz_zip_reader_init_file(&zip, zip_file_path, 0);
+	if (res)
+	{
+		sprintf(mess, _("Unzipping map\n%s"), zip_file_path);
+		statusbar_msg_add(STATUSBAR_MSG_WARN, mess);
+		int fileCount = (int)mz_zip_reader_get_num_files(&zip);
+		for ( int i = 0; i < fileCount; i++ )
+		{
+			if (!mz_zip_reader_file_stat(&zip, i, &file_stat)) continue;
+			if (mz_zip_reader_is_file_a_directory(&zip, i)) continue; // skip directories for now
+			sprintf(path, "%s/%s", target_dir, file_stat.m_filename);
+			if ( !file_exists(path) || file_size_from_name(path) != file_stat.m_uncomp_size)
+			{
+				if (!mz_zip_reader_extract_to_file(&zip, i, path, 0))
+				{
+					ERR("unzip(%s) -> %s failed with %d", zip_file_path, path, zip.m_last_error);
+					res = false;
+					break;
+				}
+			}
+		}
+	}
+	mz_zip_reader_end(&zip);
+
+	return res;
+}
+
+void maps_unzip_task(void * param)
+{
+	// Wait some time to let other things done before we start
+	osDelay(60 * 1000);
+
+	REDDIR * dir = red_opendir(PATH_MAP_DIR);
+	if (dir != NULL)
+	{
+		while (true)
+		{
+			REDDIRENT * entry = red_readdir(dir);
+			if (entry == NULL)
+				break;
+
+			char *pos = strcasestr(entry->d_name, ".zip");
+			if ( pos != NULL)
+			{
+				char file_path[PATH_LEN] = {0};
+				str_join(file_path, 3, PATH_MAP_DIR, "/", entry->d_name);
+
+				if (unzip_zipfile(PATH_MAP_DIR, file_path))
+				{
+					red_unlink(file_path);                         // Remove ZIP file, if successfull
+				}
+			}
+		}
+		red_closedir(dir);
+	}
+
+	vTaskDelete(NULL);
+}
+
+void maps_unzip_start_task()
+{
+	// Start in an own task, as it needs more stack and should run in the background.
+	xTaskCreate((TaskFunction_t)maps_unzip_task, "maps_unzip", 1024 * 8, NULL, osPriorityIdle + 4, NULL);
+}
+
+

--- a/BB3/App/system/maps_unzip.h
+++ b/BB3/App/system/maps_unzip.h
@@ -1,0 +1,16 @@
+/*
+ * maps_unzip.h
+ *
+ * Unzip all ZIP files inside the maps directory and delete ZIP afterwards.
+ *
+ *  Created on: Feb 27, 2023
+ *      Author: tilmann@bubecks.de
+ */
+
+#ifndef __MAPS_UNZIP_H
+#define __MAPS_UNZIP_H
+
+void maps_unzip_start_task();
+
+#endif
+

--- a/BB3/App/system/system_thread.c
+++ b/BB3/App/system/system_thread.c
@@ -34,6 +34,8 @@
 
 #include "SEGGER_SYSVIEW.h"
 
+#include "maps_unzip.h"
+
 //RTOS Tasks
 define_thread("Debug", thread_debug, 2024, osPriorityRealtime);
 define_thread("GUI", thread_gui, 4096, osPriorityLow);
@@ -327,6 +329,8 @@ void thread_system_start(void * argument)
 	//init FC
 	fc_init();
 
+	maps_unzip_start_task();     // Starts an own task to extract ZIP files in the background
+	
 	uint32_t power_off_timer = 0;
 	uint8_t critical_counter = 0;
 


### PR DESCRIPTION
Works fine. Two challenges, that you should address:

1. if debug_to_file is "true", then everything gets unstable and locks up easily. I dont think it has to do with unzip, but it is very obvious. To me it seems, that all the task get stucked by debug semaphore.
2. the unzip process is very slow if strato runs in normal GUI showing some widgets. According to RTOS proc, the unzip_map_task gets only <1%. When I simply open the settings menu of strato (which is less GUI), then unzip gets a real speedup. Is our GUI loop to fat?
