### PR TITLE
flightbook>flight>playback implemented

### DIFF
--- a/BB3/App/drivers/gnss/gnss_thread.c
+++ b/BB3/App/drivers/gnss/gnss_thread.c
@@ -14,71 +14,10 @@
 #include "fc/neighbors.h"
 #include "fc/navigation.h"
 
-/*
- * GPS simulation: This driver offers the functionality to simulate
- * GPS data read from a IGC file instead of the sensor. This allows
- * various flight simulations and checking, that the widgets (or other
- * code) behaves as expected.
- *
- * To use that feature define the preprocessor constant GPS_SIMULATION
- * and re-compile the code. Then place a IGC file onto the SD card as
- * "gps-sim.igc" which contains the track.
- */
-// #define GPS_SIMULATION
-
-#ifdef GPS_SIMULATION
-
-// How many times should be simulation be faster than reality?
-#define TIMEWARP 3
-
 #include "fc/logger/igc.h"
 
-static int32_t next_gps_sim = 0;
-static int32_t fp_sim = 0;
-static int heading = 0;
 
-void gps_simulation()
-{
-	int32_t now = HAL_GetTick();
-	bool ret;
 
-	if ( now > next_gps_sim )
-	{
-		next_gps_sim = now + 1000;
-
-		if ( fp_sim == 0 )
-		{
-			fp_sim = red_open("gps-sim.igc", RED_O_RDONLY);
-			if (fp_sim < 0) {
-				fp_sim = 0;
-				return;
-			}
-		}
-		flight_pos_t pos;
-		for ( int i = 0; i < TIMEWARP; i++ )
-			ret = igc_read_next_pos(fp_sim, &pos);
-		if( ret )
-		{
-			//fc.gnss.itow = ubx_nav_posllh->iTOW;
-			//disp_lat=  485547480; disp_lon =  93919890;   // Hohenneuffen
-			fc.gnss.longtitude = pos.lon;
-			fc.gnss.latitude = pos.lat;
-			//fc.gnss.altitude_above_ellipsiod = ubx_nav_posllh->height / 1000.0;
-			fc.gnss.altitude_above_msl= pos.gnss_alt;
-			//fc.gnss.horizontal_accuracy = ubx_nav_posllh->hAcc / 100;
-			//fc.gnss.vertical_accuracy = ubx_nav_posllh->vAcc / 100;
-			fc.gnss.ground_speed = 10;
-
-			fc.gnss.heading = heading;
-			heading += 30;
-			heading = heading % 360;
-
-			fc.gnss.new_sample = 0xFF;
-			fc.gnss.fix = 3;
-		}
-	}
-}
-#endif
 
 uint32_t gnss_next_pps = 0;
 
@@ -114,10 +53,11 @@ void thread_gnss_start(void * argument)
 
 	while (!system_power_off)
 	{
-#ifdef GPS_SIMULATION
-		gps_simulation();
-#else
 		ublox_step();
+
+#if 0
+		fc.gnss.longitude = 6.688914 * GNSS_MUL;
+		fc.gnss.latitude = 45.923096 * GNSS_MUL;
 #endif
 
 		fanet_step();

--- a/BB3/App/drivers/gnss/gnss_ublox_m8.c
+++ b/BB3/App/drivers/gnss/gnss_ublox_m8.c
@@ -263,16 +263,19 @@ bool ublox_handle_nav(uint8_t msg_id, uint8_t * msg_payload, uint16_t msg_len)
 
         ublox_handle_itow(ubx_nav_posllh->iTOW);
 
-		FC_ATOMIC_ACCESS
+		if (!fc_simulate_is_playing())
 		{
-			fc.gnss.itow = ubx_nav_posllh->iTOW;
-			fc.gnss.longitude = ubx_nav_posllh->lon;
-			fc.gnss.latitude = ubx_nav_posllh->lat;
-			fc.gnss.altitude_above_ellipsiod = ubx_nav_posllh->height / 1000.0;
-			fc.gnss.altitude_above_msl= ubx_nav_posllh->hMSL / 1000.0;
-			fc.gnss.horizontal_accuracy = ubx_nav_posllh->hAcc / 100;
-			fc.gnss.vertical_accuracy = ubx_nav_posllh->vAcc / 100;
-			fc.gnss.new_sample = 0xFF;
+			FC_ATOMIC_ACCESS
+			{
+				fc.gnss.itow = ubx_nav_posllh->iTOW;
+				fc.gnss.longitude = ubx_nav_posllh->lon;
+				fc.gnss.latitude = ubx_nav_posllh->lat;
+				fc.gnss.altitude_above_ellipsiod = ubx_nav_posllh->height / 1000.0;
+				fc.gnss.altitude_above_msl= ubx_nav_posllh->hMSL / 1000.0;
+				fc.gnss.horizontal_accuracy = ubx_nav_posllh->hAcc / 100;
+				fc.gnss.vertical_accuracy = ubx_nav_posllh->vAcc / 100;
+				fc.gnss.new_sample = 0xFF;
+			}
 		}
 
 		if (fc.gnss.fix > 0)
@@ -302,10 +305,13 @@ bool ublox_handle_nav(uint8_t msg_id, uint8_t * msg_payload, uint16_t msg_len)
 
 		ubx_nav_velned_t * ubx_nav_velned = (ubx_nav_velned_t *)msg_payload;
 
-		FC_ATOMIC_ACCESS
+		if (!fc_simulate_is_playing())
 		{
-			fc.gnss.ground_speed = ubx_nav_velned->gSpeed / 100.0;
-			fc.gnss.heading = ubx_nav_velned->heading / 100000;
+			FC_ATOMIC_ACCESS
+			{
+				fc.gnss.ground_speed = ubx_nav_velned->gSpeed / 100.0;
+				fc.gnss.heading = ubx_nav_velned->heading / 100000;
+			}
 		}
 
 		return true;
@@ -350,7 +356,6 @@ bool ublox_handle_nav(uint8_t msg_id, uint8_t * msg_payload, uint16_t msg_len)
 					fc.gnss.ttf = HAL_GetTick() - ublox_start_time;
 				break;
 			}
-
 		}
 
 		return true;

--- a/BB3/App/drivers/sensors/mems_thread.c
+++ b/BB3/App/drivers/sensors/mems_thread.c
@@ -119,7 +119,8 @@ void mems_phase1_1()    //pressure read completed
 {
     //start temperature measurement
     ms5611_StartTemperature(&ms_primary, mems_phase1_1_1);
-    fc.baro.pressure = ms5611_CompensatePressure(&ms_primary);
+    if (!fc_simulate_is_playing())
+    	fc.baro.pressure = ms5611_CompensatePressure(&ms_primary);
 }
 
 // --- aux baro --

--- a/BB3/App/fc/fc.c
+++ b/BB3/App/fc/fc.c
@@ -14,6 +14,7 @@
 
 #include "etc/epoch.h"
 #include "etc/timezone.h"
+#include "etc/geo_calc.h"
 
 #include "drivers/rtc.h"
 #include "drivers/gnss/fanet.h"
@@ -29,6 +30,8 @@
 
 #include "gui/tasks/page/pages.h"
 #include "etc/notifications.h"
+
+#include "fc/logger/igc.h"
 
 fc_t fc;
 
@@ -164,6 +167,8 @@ void fc_init()
 
     vario_profile_load(config_get_text(&profile.vario.profile));
 
+    fc.simulation.fh = 0;      // no simulation is running
+
     fc.airspaces.near.asn = NULL;
     fc.airspaces.near.size = 0;
     fc.airspaces.near.num = 0;
@@ -210,6 +215,101 @@ void fc_deinit()
 	fc_recorder_exit();
 }
 
+/**
+ * Give a filename of an IGC file to simulate GPS by a playback.
+ *
+ * @param filename the filename to playback
+ */
+void fc_simulate_from_igc(char *filename)
+{
+	fc_simulate_stop();
+
+	fc.simulation.fh = red_open(filename, RED_O_RDONLY);
+	if (fc.simulation.fh < 0)
+	{
+		fc.simulation.fh = 0;
+	}
+}
+
+bool fc_simulate_is_playing()
+{
+	return ( fc.simulation.fh != 0 );
+}
+
+// How many times should be simulation be faster than reality?
+#define FC_SIMULATE_TIMEWARP 3
+
+void fc_simulate_step()
+{
+	static flight_pos_t pos_prev;
+	static int32_t next_gps_sim = 0;   // HAL_GetTick when the next GPS should come
+
+	flight_pos_t pos;
+	int16_t heading;
+	uint32_t distance;
+
+	int32_t now = HAL_GetTick();
+	bool ret;
+
+	if ( now > next_gps_sim )
+	{
+		next_gps_sim = now + 1000;
+
+		for ( int i = 0; i < FC_SIMULATE_TIMEWARP; i++ )
+			ret = igc_read_next_pos(fc.simulation.fh, &pos);
+		if( ret )
+		{
+			FC_ATOMIC_ACCESS
+			{
+				//disp_lat=  485547480; disp_lon =  93919890;   // Hohenneuffen
+				fc.gnss.longitude = pos.lon;
+				fc.gnss.latitude = pos.lat;
+				//fc.gnss.altitude_above_ellipsiod = ubx_nav_posllh->height / 1000.0;
+				fc.gnss.altitude_above_msl = pos.gnss_alt;
+				//fc.gnss.horizontal_accuracy = ubx_nav_posllh->hAcc / 100;
+				//fc.gnss.vertical_accuracy = ubx_nav_posllh->vAcc / 100;
+
+				distance = geo_distance(pos_prev.lat, pos_prev.lon, pos.lat, pos.lon, false, &heading);
+				fc.gnss.ground_speed = (distance / 100.0) / FC_SIMULATE_TIMEWARP;   // cm to m
+				fc.gnss.heading = heading;
+
+				fc.gnss.new_sample = 0xFF;
+				fc.gnss.fix = 3;
+
+				// TEST: always circle
+				//	heading += 1;
+				//	heading %= 360;
+
+				fc.gnss.heading = heading;
+
+				fc.baro.pressure = fc_alt_to_press(pos.baro_alt, config_get_big_int(&config.vario.qnh1));
+			}
+
+			pos_prev = pos;
+		}
+		else
+		{
+			fc_simulate_stop();
+		}
+	}
+}
+
+/**
+ * Stop playback of IGC file.
+ */
+void fc_simulate_stop()
+{
+	int32_t fh_tmp;
+
+	// close previous file:
+	if ( fc.simulation.fh != 0 )
+	{
+		fh_tmp = fc.simulation.fh;
+		fc.simulation.fh = 0;
+		red_close(fh_tmp);
+	}
+}
+
 void fc_takeoff()
 {
     INFO("Take-off");
@@ -240,7 +340,8 @@ void fc_takeoff()
     fc.flight.mode = flight_flight;
 
     fanet_set_mode(false);
-    logger_start();
+    if (!fc_simulate_is_playing())
+    	logger_start();
     fc_recorder_reset();
 
     gui_page_set_next(&profile.ui.autoset.take_off);
@@ -295,6 +396,8 @@ void fc_landing()
 //run via timer every 250ms
 void fc_step()
 {
+	fc_simulate_step();
+
     if (fc.flight.mode == flight_wait_to_takeoff
             || fc.flight.mode == flight_landed)
     {

--- a/BB3/App/fc/fc.h
+++ b/BB3/App/fc/fc.h
@@ -461,6 +461,11 @@ typedef struct
 
 	} map_index;
 
+	struct
+	{
+		int32_t fh;          // file handle for playback of IGC or "0" is no simulation is running
+	} simulation;
+
 } fc_t;
 
 extern fc_t fc;
@@ -475,6 +480,10 @@ void fc_takeoff();
 void fc_landing();
 void fc_reset();
 void fc_step();
+
+void fc_simulate_from_igc(char *filename);
+bool fc_simulate_is_playing();
+void fc_simulate_stop();
 
 void fc_deinit();
 

--- a/BB3/App/gui/tasks/menu/flightbook/flightbook_flight.c
+++ b/BB3/App/gui/tasks/menu/flightbook/flightbook_flight.c
@@ -18,6 +18,7 @@
 #include "gui/tasks/menu/flightbook/flightbook.h"
 #include "gui/tasks/menu/flightbook/flightbook_flight.h"
 #include "gui/tasks/filemanager.h"
+#include "gui/tasks/page/pages.h"
 
 #include "gui/dialog.h"
 #include "gui/gui_list.h"
@@ -28,6 +29,8 @@
 #include "etc/format.h"
 #include "etc/geo_calc.h"
 #include "etc/epoch.h"
+
+#include "drivers/gnss/gnss_thread.h"
 
 REGISTER_TASK_I(flightbook_flight,
 	char file_path[PATH_LEN];
@@ -166,6 +169,19 @@ static bool flightbook_flight_map_cb(lv_obj_t * obj, lv_event_t event, uint16_t 
 	return true;
 }
 
+static bool flightbook_flight_playback_cb(lv_obj_t * obj, lv_event_t event, uint16_t index)
+{
+    UNUSED(index);
+
+	if (event == LV_EVENT_PRESSED)
+	{
+		fc_simulate_from_igc(local->file_path);
+        gui_switch_task(&gui_pages, LV_SCR_LOAD_ANIM_MOVE_BOTTOM);
+		return false;
+	}
+	return true;
+}
+
 static lv_obj_t * flightbook_flight_init(lv_obj_t * par)
 {
     help_set_base("Flightbook/Flight");
@@ -174,6 +190,7 @@ static lv_obj_t * flightbook_flight_init(lv_obj_t * par)
 
 	//we want to use custom callback so we can pass another parameters
 	gui_list_auto_entry(list, _h("Show on map"), CUSTOM_CB, flightbook_flight_map_cb);
+	gui_list_auto_entry(list, _h("Playback"), CUSTOM_CB, flightbook_flight_playback_cb);
 
 	return list;
 }

--- a/BB3/App/gui/tasks/menu/settings.c
+++ b/BB3/App/gui/tasks/menu/settings.c
@@ -25,15 +25,33 @@
 
 #include "gui/gui_list.h"
 #include "etc/format.h"
+#include "fc/fc.h"
 
 REGISTER_TASK_I(settings);
 
 static bool open_flightbook(lv_obj_t * obj, lv_event_t event)
 {
+	UNUSED(obj);
+
 	if (event == LV_EVENT_CLICKED)
 	{
 		flightbook_open(true);
 
+		//supress default handler
+		return false;
+	}
+	return true;
+}
+
+static bool stop_playback(lv_obj_t * obj, lv_event_t event)
+{
+	UNUSED(obj);
+
+	if (event == LV_EVENT_CLICKED)
+	{
+		fc_simulate_stop();
+
+        gui_switch_task(&gui_pages, LV_SCR_LOAD_ANIM_MOVE_BOTTOM);
 		//supress default handler
 		return false;
 	}
@@ -46,6 +64,8 @@ lv_obj_t * settings_init(lv_obj_t * par)
 
 	lv_obj_t * list = gui_list_create(par, _("Strato settings"), &gui_pages, NULL);
 
+	if (fc_simulate_is_playing())
+		gui_list_auto_entry(list, _h("Stop Playback"), CUSTOM_CB, stop_playback);
 	gui_list_auto_entry(list, _h("Flightbook"), CUSTOM_CB, open_flightbook);
 	gui_list_auto_entry(list, _h("Pilot & Flight profile"), NEXT_TASK, &gui_profiles);
 	gui_list_auto_entry(list, _h("Vario"), NEXT_TASK, &gui_vario_settings);


### PR DESCRIPTION
This allows a user to replay a recorded IGC file and see what the device will do. This is usefull to better understand the different widgets (thermalling ...) to understand what the pilot could have done better during flight.
The functionality could also be used as a demo for new users asking if a IGC should be played to see all widgets in action.