### PR TITLE
Fixed wrong IGC output for HFGPS

### DIFF
--- a/BB3/App/fc/logger/igc.c
+++ b/BB3/App/fc/logger/igc.c
@@ -212,7 +212,7 @@ void igc_start_write()
 	sprintf(line, "HFFTYFRTYPE:SkyBean,Strato");
 	igc_writeline(line);
 	//H F GPS RECEIVER
-	sprintf(line, "HFGPSRECEIVER:u-blox,NEO-M8Q,22cm,18000m");
+	sprintf(line, "HFGPSRECEIVER:u-blox,NEO-M8Q,72ch,50000m");
 	igc_writeline(line);
 	//H F PRS PRESS ALT SENSOR
 	sprintf(line, "HFPRSPRESSALTSENSOR:Measurement specialties,MS5611,25907m");


### PR DESCRIPTION
According to https://content.u-blox.com/sites/default/files/documents/NEO-M8Q-01A_DataSheet_UBX-15013820.pdf the NEO-M8Q has 72 channels and max altitude of 50000m.

Very important! Use "ch" instead of "cm"!